### PR TITLE
Correct lucky_numbers link and listed filename

### DIFF
--- a/math/lucky-numbers/README.md
+++ b/math/lucky-numbers/README.md
@@ -32,7 +32,7 @@ Therefore, set of lucky numbers  `is 1, 3, 7, 13,………`
 | Language |  Source | Run it online |
 | :-: | :-: | :-: |
 |	<img src="http://konpa.github.io/devicon/devicon.git/icons/c/c-original.svg" width="30px">                   |||
-|	<img src="http://konpa.github.io/devicon/devicon.git/icons/cplusplus/cplusplus-original.svg" width="30px">   |[lucky_number.cpp](https://github.com/AllAlgorithms/cpp/tree/master/math/lucky_number.cpp)|[repl.it](https://repl.it/@abranhe/lucky-number)|
+|	<img src="http://konpa.github.io/devicon/devicon.git/icons/cplusplus/cplusplus-original.svg" width="30px">   |[lucky_numbers.cpp](https://github.com/AllAlgorithms/cpp/tree/master/math/lucky_numbers.cpp)|[repl.it](https://repl.it/@abranhe/lucky-number)|
 |	<img src="http://konpa.github.io/devicon/devicon.git/icons/java/java-original.svg" width="30px">             |||
 |	<img src="http://konpa.github.io/devicon/devicon.git/icons/python/python-original.svg" width="30px">         |||
 |	<img src="http://konpa.github.io/devicon/devicon.git/icons/javascript/javascript-original.svg" width="30px"> |||


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Instead of being redirected to the implementation,  clicking over `lucky_number.cpp` results in a 404 error being raised.

Also, the implementation is in a file named `lucky_numbers.cpp` and not `lucky_number.cpp`

## Current behavior before PR

1. 404 error is raised when clicking over the cpp implementation of lucky numbers
2. Listed filename with the implementation does not match the actual filename

## Desired behavior after PR is merged

1. Clicking over `lucky_numbers.cpp` properly redirects to the implementation.
2. The listed filename matches the implementation filename. 