### PR TITLE
Add yarn wrapper with Docker

### DIFF
--- a/scripts/docker-yarn-start.sh
+++ b/scripts/docker-yarn-start.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+port="${1:-30000}"
+dys_inside='inside the container'
+mnt_dir='/mnt'
+
+me="$(readlink -f "$0")"
+root_dir="$(dirname "$(dirname "$me")")"
+
+case "$port" in
+   (-h|--help)
+      printf '%s [-h|--help] [<local-port>]\n' "$0"
+      ;;
+
+   ("$dys_inside")
+      cd "$root_dir/website"
+      yarn
+      yarn start
+      ;;
+
+   (*)
+      cat >&2 <<END
+
+   *** browse http://127.0.0.1:$port/ *** CTRL-C to exit ***
+
+END
+      docker run --rm -it -v "$root_dir:$mnt_dir" -p "$port:3000" \
+         node:alpine /bin/sh "$mnt_dir${me#$root_dir}" "$dys_inside"
+      ;;
+esac
+
+exit 0

--- a/templates/contributing.txt
+++ b/templates/contributing.txt
@@ -1,3 +1,8 @@
 ## Contributing
 
 > Please note that this project is released with a [Contributor Code of Conduct](code-of-conduct.md). By participating in this project you agree to abide by its terms.
+
+
+To test your contributions locally, if you have [Docker][] installed you can run `./scripts/docker-yarn-start.sh` which will run `yarn` and serve pages locally (by default on port `30000`).
+
+[Docker]: https://www.docker.com/


### PR DESCRIPTION
I am creating a pull request for...

- [ ] New algorithm
- [ ] Update to an algorithm
- [ ] Fix an error
- [X] Other - *Describe below*

This change adds `scripts/docker-yarn-start.sh` which allows serving the pages locally via nodejs/yarn from a Docker image. 

This should ease contributions by people who don't have or don't want to install nodejs/yarn but still have Docker.